### PR TITLE
Readme instructions are out of date and not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You should install pdfminer first.
 
 ### Else
 
-	git clone git@github.com:euske/pdfminer.git
+	git@github.com:johnlinp/pdf-to-markdown.git
 	cd pdfminer
 	make cmap
 	sudo python setup.py install


### PR DESCRIPTION
So here is what I did:

```
git clone git@github.com:euske/pdfminer.git
10378  cd pdfminer
10379  ls
10380  sudo python setup.py install

//Then
python main.py ~/Desktop/MyFile.pdf

➜  pdfminer git:(master) ✗ ls
MANIFEST.in Makefile    README.md   build       cmaprsrc    docs        pdfminer    samples     setup.py    tools
```

python: can't open file 'main.py': [Errno 2] No such file or directory

Am I missing a step here? Is this the correct repo to clone?
